### PR TITLE
build: add monitoring stats

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "postcss-easy-import": "~3.0.0",
     "postcss-focus": "~4.0.0",
     "postcss-loader": "~3.0.0",
+    "process-stats": "~3.0.4",
     "qsm": "~2.1.0",
     "react": "16.8.6",
     "react-bounty": "~1.0.4",

--- a/server.js
+++ b/server.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const cacheableResponse = require('cacheable-response')
+const procStats = require('process-stats')
 const express = require('express')
 const next = require('next')
 
@@ -39,7 +40,7 @@ const middleware = (() => {
 
 app.prepare().then(() => {
   const server = express()
-  server.get('/api/status', (req, res) => res.json({ deployDate: DEPLOY_DATE }))
+  server.get('/api/status', (req, res) => res.json({ ...procStats(), deployDate: DEPLOY_DATE }))
   server.use(middleware)
   server.listen(PORT, () => console.log(`> Ready on http://localhost:${PORT}`))
 })


### PR DESCRIPTION
Example of payload

```json
// 20190417130623
// http://localhost:3000/api/status

{
  "cpus": 4,
  "memFree": {
    "value": 826908672,
    "pretty": "827 MB",
    "percent": "5%"
  },
  "memTotal": {
    "value": 17179869184,
    "pretty": "17.2 GB",
    "percent": "100%"
  },
  "uptime": {
    "value": 14728.226622,
    "pretty": "14.7s"
  },
  "loadAvg": {
    "value": [
      2.76,
      2.69,
      2.66
    ],
    "normalized": [
      0.69,
      0.67,
      0.67
    ]
  },
  "cpu": "0.4%",
  "memUsed": {
    "value": 220663808,
    "pretty": "221 MB",
    "percent": "1%"
  },
  "delay": {
    "value": 0,
    "pretty": "0ms"
  },
  "deployDate": "n/a"
}
```